### PR TITLE
Add support for including specific tables

### DIFF
--- a/lib/dexter/client.rb
+++ b/lib/dexter/client.rb
@@ -30,6 +30,7 @@ module Dexter
 Options:)
         o.boolean "--create", "create indexes", default: false
         o.array "--exclude", "prevent specific tables from being indexed"
+        o.array "--include", "only include specific tables"
         o.integer "--interval", "time to wait between processing queries, in seconds", default: 60
         o.float "--min-time", "only process queries that have consumed a certain amount of DB time, in minutes", default: 0
         o.boolean "--pg-stat-statements", "use pg_stat_statements", default: false, help: false

--- a/lib/dexter/indexer.rb
+++ b/lib/dexter/indexer.rb
@@ -7,6 +7,7 @@ module Dexter
       @create = options[:create]
       @log_level = options[:log_level]
       @exclude_tables = options[:exclude]
+      @include_tables = options[:include]
       @log_sql = options[:log_sql]
       @log_explain = options[:log_explain]
       @min_time = options[:min_time] || 0
@@ -33,6 +34,11 @@ module Dexter
 
       # exclude user specified tables
       # TODO exclude write-heavy tables
+      if @include_tables
+        tables = @include_tables.select do |table|
+          tables.include? table
+        end
+      end
       @exclude_tables.each do |table|
         tables.delete(table)
       end


### PR DESCRIPTION
- add option `--include`, type array.
- include tables in the query
- example:  `dexter mydb --include users`