### PR TITLE
Add support for setting use_real_oids=on for hypopg extension

### DIFF
--- a/lib/dexter/client.rb
+++ b/lib/dexter/client.rb
@@ -73,6 +73,7 @@ module Dexter
         o.boolean "--analyze", "analyze tables that haven't been analyzed in the past hour", default: false
         o.boolean "--create", "create indexes", default: false
         o.boolean "--enable-hypopg", "enable the HypoPG extension", default: false
+        o.boolean "--enable-hypopg-use-real-oids", "enable the HypoPG hypopg.use_real_oids -configuration", default: false
         o.array "--exclude", "prevent specific tables from being indexed"
         o.string "--include", "only include specific tables"
         o.integer "--min-cost-savings-pct", default: 50, help: false

--- a/lib/dexter/indexer.rb
+++ b/lib/dexter/indexer.rb
@@ -24,6 +24,10 @@ module Dexter
       check_extension
 
       execute("SET lock_timeout = '5s'")
+
+      if @options[:enable_hypopg_use_real_oids]
+        execute("SET hypopg.use_real_oids=on")
+      end
     end
 
     def process_stat_statements


### PR DESCRIPTION
This PR adds a fix for using the hypopg extension with AWS RDS Postgres databases. It sets the `use_real_oids=on` parameter for the current session, as required for the extension to function correctly.
